### PR TITLE
Make lift speed on Attached Jump Thru more accurate

### DIFF
--- a/source/Entities/AttachedJumpThru.cs
+++ b/source/Entities/AttachedJumpThru.cs
@@ -1,4 +1,5 @@
 ﻿using Celeste.Mod.Entities;
+using Celeste.Mod.VortexHelper.Misc;
 using Microsoft.Xna.Framework;
 using Monocle;
 using MonoMod.Utils;
@@ -39,12 +40,13 @@ namespace Celeste.Mod.VortexHelper.Entities {
                 }
             };
 
-            Add(new StaticMover {
+            Add(new StaticMoverWithLiftSpeed {
                 OnMove = OnMove,
                 OnShake = OnShake,
                 SolidChecker = IsRiding,
                 OnEnable = OnEnable,
-                OnDisable = OnDisable
+                OnDisable = OnDisable,
+                OnSetLiftSpeed = OnSetLiftSpeed
             });
         }
 
@@ -122,6 +124,10 @@ namespace Celeste.Mod.VortexHelper.Entities {
             Position = position;
         }
 
+        private void OnSetLiftSpeed(Vector2 liftSpeed) {
+            LiftSpeed = liftSpeed;
+        }
+
         // Fix weird tp glitch with MoveBlocks
         private void OnMove(Vector2 amount) {
             float moveH = amount.X;
@@ -132,8 +138,8 @@ namespace Celeste.Mod.VortexHelper.Entities {
                 MoveVNaive(moveV);
             }
             else {
-                MoveH(moveH);
-                MoveV(moveV);
+                MoveH(moveH, LiftSpeed.X);
+                MoveV(moveV, LiftSpeed.Y);
             }
 
         }

--- a/source/Misc/StaticMoverWithLiftSpeed.cs
+++ b/source/Misc/StaticMoverWithLiftSpeed.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.Xna.Framework;
+using Monocle;
+using System;
+
+namespace Celeste.Mod.VortexHelper.Misc {
+    /// <summary>
+    /// A static mover that has an extra "event" OnSetLiftSpeed that is called with the exact value of the lift speed just before any move.
+    /// This allows to attach solids to solids with both solids having the same lift speed.
+    /// </summary>
+    [TrackedAs(typeof(StaticMover))]
+    public class StaticMoverWithLiftSpeed : StaticMover {
+        public Action<Vector2> OnSetLiftSpeed;
+
+        public static class Hooks {
+            private static Platform currentPlatform;
+
+            public static void Hook() {
+                On.Celeste.Platform.MoveStaticMovers += Platform_MoveStaticMovers;
+                On.Celeste.StaticMover.Move += StaticMover_Move;
+            }
+
+            public static void Unhook() {
+                On.Celeste.Platform.MoveStaticMovers -= Platform_MoveStaticMovers;
+                On.Celeste.StaticMover.Move -= StaticMover_Move;
+            }
+
+            private static void Platform_MoveStaticMovers(On.Celeste.Platform.orig_MoveStaticMovers orig, Platform self, Vector2 amount) {
+                currentPlatform = self;
+                orig(self, amount);
+                currentPlatform = null;
+            }
+
+            private static void StaticMover_Move(On.Celeste.StaticMover.orig_Move orig, StaticMover self, Vector2 amount) {
+                if (self is StaticMoverWithLiftSpeed staticMover) {
+                    staticMover.OnSetLiftSpeed?.Invoke(currentPlatform.LiftSpeed);
+                }
+
+                orig(self, amount);
+            }
+        }
+    }
+}

--- a/source/VortexHelperModule.cs
+++ b/source/VortexHelperModule.cs
@@ -60,6 +60,7 @@ namespace Celeste.Mod.VortexHelper {
             LavenderBooster.Hooks.Hook();
             BowlPuffer.Hooks.Hook();
             PufferBarrierRenderer.Hooks.Hook();
+            StaticMoverWithLiftSpeed.Hooks.Hook();
             MiscHooks.Hook();
         }
 
@@ -71,6 +72,7 @@ namespace Celeste.Mod.VortexHelper {
             LavenderBooster.Hooks.Unhook();
             BowlPuffer.Hooks.Unhook();
             PufferBarrierRenderer.Hooks.Unhook();
+            StaticMoverWithLiftSpeed.Hooks.Unhook();
             MiscHooks.Unhook();
         }
 


### PR DESCRIPTION
Implemented by @max4805, adds a `StaticMoverWithLiftSpeed` component that inherits from `StaticMover`, and which sets its own liftspeed to its parent Entity before any movement is performed. This fixes bad liftspeed values from Attached Jump Thrus.