### PR TITLE
Add custom particle colours for Vortex Bumper

### DIFF
--- a/Code/Entities/VortexBumper.cs
+++ b/Code/Entities/VortexBumper.cs
@@ -35,9 +35,12 @@ public class VortexBumper : Entity
     private readonly bool notCoreMode, wobble;
 
     public VortexBumper(EntityData data, Vector2 offset)
-        : this(data.Position + offset, data.FirstNodeNullable(offset), data.Attr("style", "Green"), data.Bool("notCoreMore"), data.Bool("wobble", true), data.Attr("sprite").Trim().TrimEnd('/')) { }
+        : this(data.Position + offset, data.FirstNodeNullable(offset), data.Attr("style", "Green"), data.Bool("notCoreMore"),
+              data.Bool("wobble", true), data.Attr("sprite").Trim().TrimEnd('/'),
+              data.Bool("useCustomParticleColors"), data.HexColor("particleColor1"), data.HexColor("particleColor2")) { }
 
-    public VortexBumper(Vector2 position, Vector2? node, string style, bool notCoreMode, bool wobble, string customSpritePath)
+    public VortexBumper(Vector2 position, Vector2? node, string style, bool notCoreMode, bool wobble, string customSpritePath,
+        bool useCustomParticleColors, Color particleColor, Color particleColor2)
         : base(position)
     {
         this.Collider = new Circle(12f);
@@ -49,21 +52,36 @@ public class VortexBumper : Entity
         if (!string.IsNullOrEmpty(customSpritePath))
             this.sprite = BuildCustomSprite(customSpritePath, style.ToLower());
 
+        // Custom particle colours support
+        if (useCustomParticleColors)
+        {
+            p_ambiance = new(Bumper.P_Ambience)
+            {
+                Color = particleColor,
+                Color2 = particleColor2
+            };
+            p_launch = new(Bumper.P_Launch)
+            {
+                Color = p_ambiance.Color,
+                Color2 = p_ambiance.Color2
+            };
+        }
+
         switch (style)
         {
             default:
             case "Green":
                 this.sprite ??= VortexHelperModule.VortexBumperSpriteBank.Create("greenBumper");
                 this.twoDashes = true;
-                this.p_ambiance = P_GreenAmbience;
-                this.p_launch = P_GreenLaunch;
+                this.p_ambiance ??= P_GreenAmbience;
+                this.p_launch ??= P_GreenLaunch;
                 break;
 
             case "Orange":
                 this.sprite ??= VortexHelperModule.VortexBumperSpriteBank.Create("orangeBumper");
                 this.oneUse = true;
-                this.p_ambiance = P_OrangeAmbience;
-                this.p_launch = P_OrangeLaunch;
+                this.p_ambiance ??= P_OrangeAmbience;
+                this.p_launch ??= P_OrangeLaunch;
                 break;
         }
         this.notCoreMode = notCoreMode;

--- a/Loenn/entities/vortex_custom_bumper.lua
+++ b/Loenn/entities/vortex_custom_bumper.lua
@@ -17,6 +17,12 @@ vortexCustomBumper.fieldInformation = {
     style = {
         options = styles,
         editable = false
+    },
+    particleColor1 = {
+        fieldType = "color"
+    },
+    particleColor2 = {
+        fieldType = "color"
     }
 }
 
@@ -28,7 +34,10 @@ for _, style in ipairs(styles) do
             style = style,
             notCoreMode = false,
             wobble = true,
-            sprite = ""
+            sprite = "",
+            useCustomParticleColors = false,
+            particleColor1 = (style == "Orange" and "cc9747") or "5dcc47",
+            particleColor2 = (style == "Orange" and "ffdfc4") or "c4ffc9"
         }
     }
     table.insert(vortexCustomBumper.placements, placement)

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -87,6 +87,9 @@ entities.VortexHelper/VortexCustomBumper.attributes.description.style=Alters the
 entities.VortexHelper/VortexCustomBumper.attributes.description.notCoreMode=Whether this bumper's style should remain the same, independently of the current Core Mode.
 entities.VortexHelper/VortexCustomBumper.attributes.description.wobble=Allows this bumper to wobble around and react to the player bouncing on it.
 entities.VortexHelper/VortexCustomBumper.attributes.description.sprite=Custom sprite path for this bumper that leads to custom frames.\nThe frame count must match the one from the original skin, and the files need to have this bumper's style as their name (all lowercase), + the frame index.\nFor instance: green00.png, green01.png, green02.png, etc... given that this bumper uses the green style.\nThe sprites must be located somewhere in the Gameplay atlas (somewhere in Graphics/Atlases/Gameplay/).\n\nExemple: objects/myMap/myCustomBumper\n..should be valid if there exists files whose paths are Graphics/Atlases/Gameplay/objects/myMap/myCustomBumper/<style>00.png, etc... (<style> is this bumper's style).
+entities.VortexHelper/VortexCustomBumper.attributes.description.useCustomParticleColors=Allows this bumper to use custom colors for its particle effects.
+entities.VortexHelper/VortexCustomBumper.attributes.description.particleColor1=Custom primary color for particle effects.\nOnly used when "Use Custom Particle Colors" is checked.
+entities.VortexHelper/VortexCustomBumper.attributes.description.particleColor2=Custom secondary color for particle effects.\nOnly used when "Use Custom Particle Colors" is checked.
 
 # Color Switch Trigger
 triggers.VortexHelper/ColorSwitchTrigger.placements.name.color_switch_trigger=Color Switch Trigger

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,5 +1,5 @@
 - Name: VortexHelper
-  Version: 1.2.14
+  Version: 1.2.15-dev
   DLL: Code/bin/VortexHelper.dll
   Dependencies:
     - Name: EverestCore

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,5 +1,5 @@
 - Name: VortexHelper
-  Version: 1.2.15-dev
+  Version: 1.2.14
   DLL: Code/bin/VortexHelper.dll
   Dependencies:
     - Name: EverestCore


### PR DESCRIPTION
This adds an option for Vortex Bumper entities to enable customising the particle colours, including the respective colour fields.

Resolves issue #36