### PR TITLE
Fix purple booster crash

### DIFF
--- a/Code/Entities/PurpleBooster.cs
+++ b/Code/Entities/PurpleBooster.cs
@@ -201,7 +201,7 @@ public class PurpleBooster : Entity
         this.linkVisible = player.StateMachine.State is Player.StDash or Player.StNormal;
         this.linkPercent = this.linkVisible ? 0.0f : 1.0f;
 
-        if (!this.linkVisible)
+        if (!this.linkVisible && !player.Dead)
             LaunchPlayerParticles(player, -dir, P_BurstExplode);
 
         while (SceneAs<Level>().Transitioning)


### PR DESCRIPTION
This fixes a crash where the player dies and gets removed from the scene the frame a boost ends.

Closes #33 