### PR TITLE
Gravity Helper support + other fixes

### DIFF
--- a/Code/Entities/BowlPuffer.cs
+++ b/Code/Entities/BowlPuffer.cs
@@ -1,4 +1,5 @@
 ﻿using Celeste.Mod.Entities;
+using Celeste.Mod.VortexHelper.Misc;
 using Microsoft.Xna.Framework;
 using Monocle;
 using System;
@@ -341,7 +342,7 @@ public class BowlPuffer : Actor
 
     #endregion
 
-    #region Explosiong
+    #region Explosion
 
     private void Explode(bool playsound = true)
     {
@@ -764,6 +765,21 @@ public class BowlPuffer : Actor
     {
         this.puffer.Scale = this.scale * (1f + this.inflateWiggler.Value * 0.4f);
         this.puffer.FlipX = false;
+        
+        // gravity helper forces a scale change on the default Sprite
+        if (Get<Sprite>() is { } sprite) sprite.Scale.Y = Math.Abs(sprite.Scale.Y);
+        
+        // invert sprites if required
+        var inverted = GravityHelperInterop.IsActorInverted(this);
+        if (inverted)
+        {
+            this.puffer.Y *= -1;
+            this.pufferBowlTop.Y *= -1;
+            this.pufferBowlBottom.Y *= -1;
+            this.pufferBowlTop.Scale.Y *= -1;
+            this.pufferBowlBottom.Scale.Y *= -1;
+            this.puffer.Scale.Y *= -1;
+        }
 
         Vector2 position = this.Position;
         this.Position.Y -= 6.0f;
@@ -791,6 +807,16 @@ public class BowlPuffer : Actor
                 Vector2 p = this.Center + new Vector2((float) Math.Sin(a), -(float) Math.Cos(a)) * 16 - Vector2.UnitY * 5 - Vector2.UnitX;
                 Draw.Point(p, Color.Lerp(Color.OrangeRed, Color.LawnGreen, a / (float) Math.PI));
             }
+        }
+        
+        if (inverted)
+        {
+            this.puffer.Y *= -1;
+            this.pufferBowlTop.Y *= -1;
+            this.pufferBowlBottom.Y *= -1;
+            this.pufferBowlTop.Scale.Y *= -1;
+            this.pufferBowlBottom.Scale.Y *= -1;
+            this.puffer.Scale.Y *= -1;
         }
     }
 

--- a/Code/Misc/GravityHelperInterop.cs
+++ b/Code/Misc/GravityHelperInterop.cs
@@ -1,0 +1,15 @@
+﻿using MonoMod.ModInterop;
+using System;
+
+namespace Celeste.Mod.VortexHelper.Misc;
+
+internal static class GravityHelperInterop
+{
+    [ModImportName("GravityHelper")]
+    internal static class Imports
+    {
+        public static Func<bool> IsPlayerInverted;
+    }
+
+    public static bool IsPlayerInverted() => Imports.IsPlayerInverted?.Invoke() ?? false;
+}

--- a/Code/Misc/GravityHelperInterop.cs
+++ b/Code/Misc/GravityHelperInterop.cs
@@ -9,7 +9,9 @@ internal static class GravityHelperInterop
     internal static class Imports
     {
         public static Func<bool> IsPlayerInverted;
+        public static Func<Actor, bool> IsActorInverted;
     }
 
     public static bool IsPlayerInverted() => Imports.IsPlayerInverted?.Invoke() ?? false;
+    public static bool IsActorInverted(Actor actor) => Imports.IsActorInverted?.Invoke(actor) ?? false;
 }

--- a/Code/Misc/GravityHelperInterop.cs
+++ b/Code/Misc/GravityHelperInterop.cs
@@ -1,4 +1,5 @@
-﻿using MonoMod.ModInterop;
+﻿using Microsoft.Xna.Framework;
+using MonoMod.ModInterop;
 using System;
 
 namespace Celeste.Mod.VortexHelper.Misc;
@@ -10,8 +11,13 @@ internal static class GravityHelperInterop
     {
         public static Func<bool> IsPlayerInverted;
         public static Func<Actor, bool> IsActorInverted;
+        public static Action BeginOverride;
+        public static Action EndOverride;
     }
 
     public static bool IsPlayerInverted() => Imports.IsPlayerInverted?.Invoke() ?? false;
     public static bool IsActorInverted(Actor actor) => Imports.IsActorInverted?.Invoke(actor) ?? false;
+    public static void BeginOverride() => Imports.BeginOverride?.Invoke();
+    public static void EndOverride() => Imports.EndOverride?.Invoke();
+    public static Vector2 InvertIfRequired(Vector2 v) => IsPlayerInverted() ? new Vector2(v.X, -v.Y) : v;
 }

--- a/Code/VortexHelperModule.cs
+++ b/Code/VortexHelperModule.cs
@@ -2,6 +2,7 @@
 using Celeste.Mod.VortexHelper.Misc;
 using Microsoft.Xna.Framework;
 using Monocle;
+using MonoMod.ModInterop;
 using System;
 using System.Reflection;
 
@@ -69,6 +70,8 @@ public class VortexHelperModule : EverestModule
         MiscHooks.Hook();
 
         Util.LoadDelegates();
+        
+        typeof(GravityHelperInterop.Imports).ModInterop();
     }
 
     public override void Unload()

--- a/Loenn/entities/bowl_puffer.lua
+++ b/Loenn/entities/bowl_puffer.lua
@@ -29,7 +29,7 @@ bowlPuffer.placements = {
 }
 
 bowlPuffer.texture = "objects/VortexHelper/pufferBowl/idle00"
-bowlPuffer.offset = {32, 35}
+bowlPuffer.offset = {0, 3}
 
 function bowlPuffer.selection(room, entity)
     return utils.rectangle((entity.x or 0) - 11, (entity.y or 0) - 11, 21, 19)

--- a/Loenn/entities/floor_booster.lua
+++ b/Loenn/entities/floor_booster.lua
@@ -20,6 +20,7 @@ floorBooster.placements = {
         data = {
             width = 8,
             left = false,
+            ceiling = false,
             iceMode = false,
             speed = 110,
             noRefillOnIce = true,
@@ -32,6 +33,33 @@ floorBooster.placements = {
         data = {
             width = 8,
             left = true,
+            ceiling = false,
+            iceMode = false,
+            speed = 110,
+            noRefillOnIce = true,
+            notAttached = false
+        }
+    },
+    {
+        name = "right_ceiling",
+        placementType = "rectangle",
+        data = {
+            width = 8,
+            left = false,
+            ceiling = true,
+            iceMode = false,
+            speed = 110,
+            noRefillOnIce = true,
+            notAttached = false
+        }
+    },
+    {
+        name = "left_ceiling",
+        placementType = "rectangle",
+        data = {
+            width = 8,
+            left = true,
+            ceiling = true,
             iceMode = false,
             speed = 110,
             noRefillOnIce = true,
@@ -60,9 +88,11 @@ function floorBooster.sprite(room, entity)
     local sprites = {}
 
     local left = entity.left
+    local ceiling = entity.ceiling ~= nil and entity.ceiling
     local width = entity.width or 8
     local tileWidth = math.floor(width / 8)
-    local scale = left and 1 or -1
+    local xScale = left and 1 or -1
+    local yScale = ceiling and -1 or 1
     local offset = left and 0 or 8
 
     local leftTexture, middleTexture, rightTexture = getTextures(entity)
@@ -73,9 +103,9 @@ function floorBooster.sprite(room, entity)
     for i = 2, tileWidth - 1 do
         local middleSprite = drawableSprite.fromTexture(middleTexture, entity)
 
-        middleSprite:addPosition((i - 1) * 8 + offset, 0)
-        middleSprite:setScale(scale, 1)
-        middleSprite:setJustification(0.0, 0.0)
+        middleSprite:addPosition((i - 1) * 8 + offset, 4)
+        middleSprite:setScale(xScale, yScale)
+        middleSprite:setJustification(0.0, 0.5)
 
         table.insert(sprites, middleSprite)
     end
@@ -83,13 +113,13 @@ function floorBooster.sprite(room, entity)
     local leftSprite = drawableSprite.fromTexture(leftTexture, entity)
     local rightSprite = drawableSprite.fromTexture(rightTexture, entity)
 
-    leftSprite:addPosition(offset, 0)
-    leftSprite:setScale(scale, 1)
-    leftSprite:setJustification(0.0, 0.0)
+    leftSprite:addPosition(offset, 4)
+    leftSprite:setScale(xScale, yScale)
+    leftSprite:setJustification(0.0, 0.5)
 
-    rightSprite:addPosition((tileWidth - 1) * 8 + offset, 0)
-    rightSprite:setScale(scale, 1)
-    rightSprite:setJustification(0.0, 0.0)
+    rightSprite:addPosition((tileWidth - 1) * 8 + offset, 4)
+    rightSprite:setScale(xScale, yScale)
+    rightSprite:setJustification(0.0, 0.5)
 
     table.insert(sprites, leftSprite)
     table.insert(sprites, rightSprite)
@@ -99,6 +129,12 @@ end
 
 function floorBooster.rectangle(room, entity)
     return utils.rectangle(entity.x, entity.y, entity.width or 8, 8)
+end
+
+function floorBooster.flip(room, entity, horizontal, vertical)
+    if vertical then entity.ceiling = not entity.ceiling end
+    if horizontal then entity.left = not entity.left end
+    return true
 end
 
 return floorBooster

--- a/Loenn/entities/floor_booster.lua
+++ b/Loenn/entities/floor_booster.lua
@@ -13,6 +13,13 @@ floorBooster.fieldInformation = {
     }
 }
 
+floorBooster.fieldOrder = {
+    "x", "y",
+    "width", "speed",
+    "iceMode", "left", "noRefillOnIce", "notAttached",
+    "ceiling"
+}
+
 floorBooster.placements = {
     {
         name = "right",
@@ -134,7 +141,7 @@ end
 function floorBooster.flip(room, entity, horizontal, vertical)
     if vertical then entity.ceiling = not entity.ceiling end
     if horizontal then entity.left = not entity.left end
-    return true
+    return vertical or horizontal
 end
 
 return floorBooster

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -50,10 +50,13 @@ entities.VortexHelper/DashBubble.attributes.description.spiked=Adds spikes to th
 entities.VortexHelper/DashBubble.attributes.description.singleUse=Makes this bubble usable only once.
 entities.VortexHelper/DashBubble.attributes.description.wobble=Allows this bubble to wobble around its position, and to react to the player bouncing on it.
 
-# Floor Booster
+# Floor/Ceiling Booster
 entities.VortexHelper/FloorBooster.placements.name.right=Floor Booster (Right)
 entities.VortexHelper/FloorBooster.placements.name.left=Floor Booster (Left)
+entities.VortexHelper/FloorBooster.placements.name.right_ceiling=Ceiling Booster (Right)
+entities.VortexHelper/FloorBooster.placements.name.left_ceiling=Ceiling Booster (Left)
 entities.VortexHelper/FloorBooster.attributes.description.left=Makes this Floor Booster push towards the left.
+entities.VortexHelper/FloorBooster.attributes.description.ceiling=Whether the Floor Booster should attach to the ceiling. Only applies to Gravity Helper.
 entities.VortexHelper/FloorBooster.attributes.description.iceMode=Whether the Floor Booster should ignore the current Core mode and default to ice variant.
 entities.VortexHelper/FloorBooster.attributes.description.speed=The speed of this Floor Booster.
 entities.VortexHelper/FloorBooster.attributes.description.noRefillOnIce=Whether the ice variant should prevent dash refills when stood on.

--- a/everest.yaml
+++ b/everest.yaml
@@ -4,3 +4,6 @@
   Dependencies:
     - Name: EverestCore
       Version: 1.4465.0
+  OptionalDependencies:
+    - Name: GravityHelper
+      Version: 1.2.10


### PR DESCRIPTION
Adds Gravity Helper support to:
* Puffer Bowls
* Purple Boosters
* Lavender Boosters
* Floor Boosters (new ceiling variant)

Plugin changes:
* Puffer Bowl sprite offset fixed
* Floor/Ceiling boosters now support flip shortcuts (H and V)