### PR TITLE
Add holdable and flag interactions with Color Switches

### DIFF
--- a/Code/Entities/ColorSwitch.cs
+++ b/Code/Entities/ColorSwitch.cs
@@ -29,12 +29,14 @@ public class ColorSwitch : Solid
     private int nextColorIndex = 0;
     private readonly bool singleColor, random;
 
+    private readonly bool holdableActivated;
+
     public ColorSwitch(EntityData data, Vector2 offset)
         : this(data.Position + offset, data.Width, data.Height,
-              data.Bool("blue"), data.Bool("rose"), data.Bool("orange"), data.Bool("lime"), data.Bool("random"))
+              data.Bool("blue"), data.Bool("rose"), data.Bool("orange"), data.Bool("lime"), data.Bool("random"), data.Bool("holdableActivated"))
     { }
 
-    public ColorSwitch(Vector2 position, int width, int height, bool blue, bool rose, bool orange, bool lime, bool random)
+    public ColorSwitch(Vector2 position, int width, int height, bool blue, bool rose, bool orange, bool lime, bool random, bool holdableActivated)
         : base(position, width, height, true)
     {
         this.SurfaceSoundIndex = SurfaceIndex.ZipMover;
@@ -78,6 +80,7 @@ public class ColorSwitch : Solid
         SetEdgeColor(this.EdgeColor, this.EdgeColor);
         SetBackgroundColor(col, col);
 
+        this.holdableActivated = holdableActivated;
         this.OnDashCollide = Dashed;
     }
 
@@ -266,5 +269,39 @@ public class ColorSwitch : Solid
 
         num += 2;
         SceneAs<Level>().Particles.Emit(smashParticle, num, position, positionRange, direction);
+    }
+
+    internal static class Hooks
+    {
+        public static void Hook()
+        {
+            On.Celeste.TheoCrystal.OnCollideH += TheoCrystal_OnCollideH;
+            On.Celeste.TheoCrystal.OnCollideV += TheoCrystal_OnCollideV;
+            On.Celeste.Glider.OnCollideH += Glider_OnCollideH;
+        }
+
+        public static void Unhook()
+        {
+            On.Celeste.TheoCrystal.OnCollideH -= TheoCrystal_OnCollideH;
+            On.Celeste.TheoCrystal.OnCollideV -= TheoCrystal_OnCollideV;
+            On.Celeste.Glider.OnCollideH -= Glider_OnCollideH;
+        }
+
+        private static void ActivateSwitch(Action callOrig, CollisionData data, Func<bool> speedChecker)
+        {
+            if (data.Hit is ColorSwitch colorSwitch
+                && colorSwitch.holdableActivated
+                && !colorSwitch.colors[colorSwitch.nextColorIndex].IsActive()
+                && speedChecker())
+            {
+                colorSwitch.Switch(data.Direction);
+            }
+
+            callOrig();
+        }
+
+        private static void TheoCrystal_OnCollideH(On.Celeste.TheoCrystal.orig_OnCollideH orig, TheoCrystal self, CollisionData data) => ActivateSwitch(() => orig(self, data), data, () => Math.Abs(self.Speed.X) > 100f);
+        private static void TheoCrystal_OnCollideV(On.Celeste.TheoCrystal.orig_OnCollideV orig, TheoCrystal self, CollisionData data) => ActivateSwitch(() => orig(self, data), data, () => self.Speed.Y > 160f);
+        private static void Glider_OnCollideH(On.Celeste.Glider.orig_OnCollideH orig, Glider self, CollisionData data) => ActivateSwitch(() => orig(self, data), data, () => Math.Abs(self.Speed.X) > 60f);
     }
 }

--- a/Code/Entities/ColorSwitch.cs
+++ b/Code/Entities/ColorSwitch.cs
@@ -278,6 +278,7 @@ public class ColorSwitch : Solid
             On.Celeste.TheoCrystal.OnCollideH += TheoCrystal_OnCollideH;
             On.Celeste.TheoCrystal.OnCollideV += TheoCrystal_OnCollideV;
             On.Celeste.Glider.OnCollideH += Glider_OnCollideH;
+            On.Celeste.Glider.OnCollideV += Glider_OnCollideV;
         }
 
         public static void Unhook()
@@ -285,6 +286,7 @@ public class ColorSwitch : Solid
             On.Celeste.TheoCrystal.OnCollideH -= TheoCrystal_OnCollideH;
             On.Celeste.TheoCrystal.OnCollideV -= TheoCrystal_OnCollideV;
             On.Celeste.Glider.OnCollideH -= Glider_OnCollideH;
+            On.Celeste.Glider.OnCollideV -= Glider_OnCollideV;
         }
 
         private static void ActivateSwitch(Action callOrig, CollisionData data, Func<bool> speedChecker)
@@ -300,8 +302,9 @@ public class ColorSwitch : Solid
             callOrig();
         }
 
-        private static void TheoCrystal_OnCollideH(On.Celeste.TheoCrystal.orig_OnCollideH orig, TheoCrystal self, CollisionData data) => ActivateSwitch(() => orig(self, data), data, () => Math.Abs(self.Speed.X) > 100f);
-        private static void TheoCrystal_OnCollideV(On.Celeste.TheoCrystal.orig_OnCollideV orig, TheoCrystal self, CollisionData data) => ActivateSwitch(() => orig(self, data), data, () => self.Speed.Y > 160f);
-        private static void Glider_OnCollideH(On.Celeste.Glider.orig_OnCollideH orig, Glider self, CollisionData data) => ActivateSwitch(() => orig(self, data), data, () => Math.Abs(self.Speed.X) > 60f);
+        private static void TheoCrystal_OnCollideH(On.Celeste.TheoCrystal.orig_OnCollideH orig, TheoCrystal self, CollisionData data) => ActivateSwitch(() => orig(self, data), data, () => true);
+        private static void TheoCrystal_OnCollideV(On.Celeste.TheoCrystal.orig_OnCollideV orig, TheoCrystal self, CollisionData data) => ActivateSwitch(() => orig(self, data), data, () => self.Speed.Y > 160f || self.Speed.Y < 0f);
+        private static void Glider_OnCollideH(On.Celeste.Glider.orig_OnCollideH orig, Glider self, CollisionData data) => ActivateSwitch(() => orig(self, data), data, () => true);
+        private static void Glider_OnCollideV(On.Celeste.Glider.orig_OnCollideV orig, Glider self, CollisionData data) => ActivateSwitch(() => orig(self, data), data, () => self.Speed.Y < 0f);
     }
 }

--- a/Code/Entities/ColorSwitchFlagsController.cs
+++ b/Code/Entities/ColorSwitchFlagsController.cs
@@ -1,0 +1,48 @@
+using Monocle;
+using Microsoft.Xna.Framework;
+using System.Collections.Generic;
+
+namespace Celeste.Mod.VortexHelper.Entities;
+
+public class ColorSwitchFlagsController : Entity
+{
+    private static readonly Dictionary<VortexHelperSession.SwitchBlockColor, string> colorsToFlagNames = new() {
+        { VortexHelperSession.SwitchBlockColor.Blue, "VortexHelper/SwitchBlockColor_Blue" },
+        { VortexHelperSession.SwitchBlockColor.Rose, "VortexHelper/SwitchBlockColor_Rose" },
+        { VortexHelperSession.SwitchBlockColor.Lime, "VortexHelper/SwitchBlockColor_Lime" },
+        { VortexHelperSession.SwitchBlockColor.Orange, "VortexHelper/SwitchBlockColor_Orange" },
+    };
+
+    public ColorSwitchFlagsController() : base(Vector2.Zero)
+    {
+        Depth = -int.MaxValue; // update last
+        Tag = Tags.Global | Tags.TransitionUpdate;
+    }
+
+    public override void Update()
+    {
+        Session session = SceneAs<Level>().Session;
+
+        foreach (string flag in colorsToFlagNames.Values)
+        {
+            session.SetFlag(flag, false);
+        }
+
+        session.SetFlag(colorsToFlagNames[VortexHelperModule.SessionProperties.SessionSwitchBlockColor]);
+    }
+
+    internal static class Hooks
+    {
+        public static void Hook()
+        {
+            Everest.Events.LevelLoader.OnLoadingThread += OnLoadingThread;
+        }
+
+        public static void Unhook()
+        {
+            Everest.Events.LevelLoader.OnLoadingThread -= OnLoadingThread;
+        }
+
+        private static void OnLoadingThread(Level level) => level.Add(new ColorSwitchFlagsController());
+    }
+}

--- a/Code/Entities/ColorSwitchFlagsController.cs
+++ b/Code/Entities/ColorSwitchFlagsController.cs
@@ -22,13 +22,15 @@ public class ColorSwitchFlagsController : Entity
     public override void Update()
     {
         Session session = SceneAs<Level>().Session;
+        VortexHelperSession.SwitchBlockColor current = VortexHelperModule.SessionProperties.SessionSwitchBlockColor;
 
-        foreach (string flag in colorsToFlagNames.Values)
+        foreach (var color in colorsToFlagNames)
         {
-            session.SetFlag(flag, false);
+            if (current != color.Key && session.GetFlag(color.Value))
+                session.SetFlag(color.Value, false);
+            else if (current == color.Key && !session.GetFlag(color.Value))
+                session.SetFlag(color.Value, true);
         }
-
-        session.SetFlag(colorsToFlagNames[VortexHelperModule.SessionProperties.SessionSwitchBlockColor]);
     }
 
     internal static class Hooks

--- a/Code/VortexHelperModule.cs
+++ b/Code/VortexHelperModule.cs
@@ -67,10 +67,12 @@ public class VortexHelperModule : EverestModule
         BowlPuffer.Hooks.Hook();
         PufferBarrierRenderer.Hooks.Hook();
         StaticMoverWithLiftSpeed.Hooks.Hook();
+        ColorSwitch.Hooks.Hook();
+        ColorSwitchFlagsController.Hooks.Hook();
         MiscHooks.Hook();
 
         Util.LoadDelegates();
-        
+
         typeof(GravityHelperInterop.Imports).ModInterop();
     }
 
@@ -84,6 +86,8 @@ public class VortexHelperModule : EverestModule
         BowlPuffer.Hooks.Unhook();
         PufferBarrierRenderer.Hooks.Unhook();
         StaticMoverWithLiftSpeed.Hooks.Unhook();
+        ColorSwitch.Hooks.Unhook();
+        ColorSwitchFlagsController.Hooks.Unhook();
         MiscHooks.Unhook();
     }
 

--- a/Loenn/entities/color_switch.lua
+++ b/Loenn/entities/color_switch.lua
@@ -17,7 +17,8 @@ colorSwitch.placements = {
             rose = true,
             orange = true,
             lime = true,
-            random = false
+            random = false,
+            holdableActivated = false
         }
     },
     {
@@ -29,7 +30,8 @@ colorSwitch.placements = {
             rose = true,
             orange = true,
             lime = true,
-            random = true
+            random = true,
+            holdableActivated = false
         }
     }
 }

--- a/Loenn/entities/color_switch.lua
+++ b/Loenn/entities/color_switch.lua
@@ -7,6 +7,12 @@ colorSwitch.name = "VortexHelper/ColorSwitch"
 colorSwitch.resizable = {true, true}
 colorSwitch.minimumSize = {16, 16}
 
+colorSwitch.fieldOrder = {
+    "x", "y", "width", "height",
+    "blue", "rose", "orange", "lime", "random",
+    "holdableActivated"
+}
+
 colorSwitch.placements = {
     {
         name = "all_cycle",

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -35,6 +35,7 @@ entities.VortexHelper/ColorSwitch.attributes.description.rose=Enables switch to 
 entities.VortexHelper/ColorSwitch.attributes.description.orange=Enables switch to ORANGE through this Color Switch.
 entities.VortexHelper/ColorSwitch.attributes.description.lime=Enables switch to LIME through this Color Switch.
 entities.VortexHelper/ColorSwitch.attributes.description.random=Makes this Color Switch randomly pick one of its enabled colors.
+entities.VortexHelper/ColorSwitch.attributes.description.holdableActivated=Makes collisions with holdables (Jellyfish and Theo Crystals) activate this Color Switch.
 
 # Vortex Switch Gate
 entities.VortexHelper/VortexSwitchGate.placements.name.crush=Custom Switch Gate (Crush)


### PR DESCRIPTION
Allows Color Switches to be activated by holdable collisions. Only works for vanilla entities (Jellyfish and Theo Crystals).
Also, a flag is now set corresponding to the current active switch block color. Currently read-only, i.e. setting this flag to a different value will not change the current switch block color.